### PR TITLE
[WIP] Django 4.2 upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,11 @@ repos:
         files: \.(py|sh|rst|yml|yaml)$
     -   id: trailing-whitespace
         files: \.(py|sh|rst|yml|yaml)$
+-   repo: https://github.com/adamchainz/django-upgrade
+    rev: 1.13.0
+    hooks:
+    -   id: django-upgrade
+        args: [--target-version, "4.2"]
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/Turnauswertung-py3/Turnauswertung/settings.py
+++ b/Turnauswertung-py3/Turnauswertung/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'ys-#t((t5g8^p-@9sn3@artu2_5my==hvd&vgmc1ho_@$nu(gw'
+SECRET_KEY = "ys-#t((t5g8^p-@9sn3@artu2_5my==hvd&vgmc1ho_@$nu(gw"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -31,42 +31,40 @@ ALLOWED_HOSTS = []
 
 # Application definition
 INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-
-    'bootstrap3',
-    'widget_tweaks',
-
-    'common',
-    'athletes',
-    'clubs',
-    'utils',
-    'squads',
-    'streams',
-    'teams',
-    'tournaments',
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "bootstrap3",
+    "widget_tweaks",
+    "common",
+    "athletes",
+    "clubs",
+    "utils",
+    "squads",
+    "streams",
+    "teams",
+    "tournaments",
 )
 
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
+MIDDLEWARE = (
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    # 'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    # 'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
 
-ROOT_URLCONF = 'Turnauswertung.urls'
+ROOT_URLCONF = "Turnauswertung.urls"
 
-WSGI_APPLICATION = 'Turnauswertung.wsgi.application'
+WSGI_APPLICATION = "Turnauswertung.wsgi.application"
 
-MEDIA_ROOT = 'static/'
+MEDIA_ROOT = "static/"
 
 
 # Database
@@ -79,14 +77,14 @@ DATABASES = {
     #     'USER': 'root',
     #     'PASSWORD': 'root',
     # },
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
     },
-    'sqlite_fallback': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
+    "sqlite_fallback": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+    },
 }
 
 # Internationalization
@@ -96,11 +94,11 @@ DATABASES = {
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
 # In a Windows environment this must be set to your system time zone.
-TIME_ZONE = 'Europe/Berlin'
+TIME_ZONE = "Europe/Berlin"
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
@@ -117,44 +115,40 @@ USE_TZ = False
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.7/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"
 
 # List of finder classes that know how to find static files in
 # various locations.
 STATICFILES_FINDERS = (
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'django.contrib.staticfiles.finders.DefaultStorageFinder',
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+    "django.contrib.staticfiles.finders.DefaultStorageFinder",
 )
 
 
-MESSAGE_TAGS = {
-    messages.ERROR: 'danger'
-}
+MESSAGE_TAGS = {messages.ERROR: "danger"}
 
 
 # Multi-language support
-LOCALE_PATHS = (
-    os.path.join(BASE_DIR, 'locale/'),
-)
+LOCALE_PATHS = (os.path.join(BASE_DIR, "locale/"),)
 
 # TODO fix language support. Maybe eu-us and de-de?
 LANGUAGES = (
-    ('en', _('English')),
-    ('de', _('German')),
+    ("en", _("English")),
+    ("de", _("German")),
 )
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.join(BASE_DIR, 'templates')],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.contrib.auth.context_processors.auth',
-                'django.template.context_processors.i18n',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [os.path.join(BASE_DIR, "templates")],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.i18n",
             ],
-            'debug': DEBUG,
+            "debug": DEBUG,
         },
     },
 ]

--- a/Turnauswertung-py3/Turnauswertung/settings.py
+++ b/Turnauswertung-py3/Turnauswertung/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 import os
 
 from django.contrib.messages import constants as messages
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
@@ -108,7 +108,6 @@ USE_I18N = True
 
 # If you set this to False, Django will not format dates, numbers and
 # calendars according to the current locale.
-USE_L10N = True
 # USE_THOUSAND_SEPARATOR = True
 
 # If you set this to False, Django will not use timezone-aware datetimes.

--- a/Turnauswertung-py3/Turnauswertung/settings.py
+++ b/Turnauswertung-py3/Turnauswertung/settings.py
@@ -30,9 +30,7 @@ ALLOWED_HOSTS = []
 
 
 # Application definition
-
 INSTALLED_APPS = (
-    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -50,8 +48,6 @@ INSTALLED_APPS = (
     'streams',
     'teams',
     'tournaments',
-
-    'debug_toolbar',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -143,6 +139,7 @@ LOCALE_PATHS = (
     os.path.join(BASE_DIR, 'locale/'),
 )
 
+# TODO fix language support. Maybe eu-us and de-de?
 LANGUAGES = (
     ('en', _('English')),
     ('de', _('German')),

--- a/Turnauswertung-py3/Turnauswertung/urls.py
+++ b/Turnauswertung-py3/Turnauswertung/urls.py
@@ -1,16 +1,16 @@
-from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
 from django.http import HttpResponseRedirect
+from django.urls import include, path
 
 urlpatterns = i18n_patterns(
-    url(r'^$', lambda r: HttpResponseRedirect('common/')),
+    path('', lambda r: HttpResponseRedirect('common/')),
 
-    url(r'^common/', include('common.urls')),
+    path('common/', include('common.urls')),
 
-    url(r'^athletes/', include('athletes.urls')),
-    url(r'^clubs/', include('clubs.urls')),
-    url(r'^squads/', include('squads.urls')),
-    url(r'^streams/', include('streams.urls')),
-    url(r'^teams/', include('teams.urls')),
-    url(r'^tournaments/', include('tournaments.urls')),
+    path('athletes/', include('athletes.urls')),
+    path('clubs/', include('clubs.urls')),
+    path('squads/', include('squads.urls')),
+    path('streams/', include('streams.urls')),
+    path('teams/', include('teams.urls')),
+    path('tournaments/', include('tournaments.urls')),
 )

--- a/Turnauswertung-py3/Turnauswertung/urls.py
+++ b/Turnauswertung-py3/Turnauswertung/urls.py
@@ -1,13 +1,8 @@
 from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
-from django.contrib import admin
 from django.http import HttpResponseRedirect
 
-urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
-]
-
-urlpatterns += i18n_patterns(
+urlpatterns = i18n_patterns(
     url(r'^$', lambda r: HttpResponseRedirect('common/')),
 
     url(r'^common/', include('common.urls')),

--- a/Turnauswertung-py3/athletes/models.py
+++ b/Turnauswertung-py3/athletes/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.urls import reverse
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 
 class AthleteQuerySet(models.QuerySet):
@@ -26,24 +26,24 @@ class AthleteManager(models.Manager):
 
 class Athlete(models.Model):
 
-    first_name = models.CharField(ugettext_lazy('First name'), max_length=50)
-    last_name = models.CharField(ugettext_lazy('Last name'), max_length=50)
-    sex = models.CharField(ugettext_lazy('Sex'), max_length=1, choices=(('m', 'male'), ('f', 'female')), default='f')
+    first_name = models.CharField(gettext_lazy('First name'), max_length=50)
+    last_name = models.CharField(gettext_lazy('Last name'), max_length=50)
+    sex = models.CharField(gettext_lazy('Sex'), max_length=1, choices=(('m', 'male'), ('f', 'female')), default='f')
     date_of_birth = models.DateField(
-        ugettext_lazy('Date of birth'), default='1900-01-01')
+        gettext_lazy('Date of birth'), default='1900-01-01')
 
     club = models.ForeignKey(
-        'clubs.Club', null=True, blank=True, on_delete=models.CASCADE, verbose_name=ugettext_lazy('Club')
+        'clubs.Club', null=True, blank=True, on_delete=models.CASCADE, verbose_name=gettext_lazy('Club')
     )
     stream = models.ForeignKey(
-        'streams.Stream', on_delete=models.CASCADE, verbose_name=ugettext_lazy('Stream'))
+        'streams.Stream', on_delete=models.CASCADE, verbose_name=gettext_lazy('Stream'))
     team = models.ForeignKey(
         'teams.Team', null=True, blank=True, on_delete=models.SET_NULL,
-        verbose_name=ugettext_lazy('Team')
+        verbose_name=gettext_lazy('Team')
     )
     squad = models.ForeignKey(
         'squads.Squad', null=True, blank=True, on_delete=models.SET_NULL,
-        verbose_name=ugettext_lazy('Squad')
+        verbose_name=gettext_lazy('Squad')
     )
     squad_position = models.IntegerField(default=-1, null=True, blank=True)
 
@@ -100,10 +100,10 @@ class AthletesImport(models.Model):
 
     # name = models.CharField(max_length=50, null=False)
 
-    club = models.OneToOneField('clubs.Club', null=True, blank=True, on_delete=models.SET_NULL, verbose_name=ugettext_lazy('Club'))
+    club = models.OneToOneField('clubs.Club', null=True, blank=True, on_delete=models.SET_NULL, verbose_name=gettext_lazy('Club'))
 
     class Meta:
         app_label = "athletes"
 
     def __str__(self):
-        return '{0} #{1}'.format(ugettext_lazy('Athletes Import'), self.id)
+        return '{0} #{1}'.format(gettext_lazy('Athletes Import'), self.id)

--- a/Turnauswertung-py3/athletes/models.py
+++ b/Turnauswertung-py3/athletes/models.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.db import models
+from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy
 
@@ -33,10 +33,10 @@ class Athlete(models.Model):
         ugettext_lazy('Date of birth'), default='1900-01-01')
 
     club = models.ForeignKey(
-        'clubs.Club', null=True, blank=True, verbose_name=ugettext_lazy('Club')
+        'clubs.Club', null=True, blank=True, on_delete=models.CASCADE, verbose_name=ugettext_lazy('Club')
     )
     stream = models.ForeignKey(
-        'streams.Stream', verbose_name=ugettext_lazy('Stream'))
+        'streams.Stream', on_delete=models.CASCADE, verbose_name=ugettext_lazy('Stream'))
     team = models.ForeignKey(
         'teams.Team', null=True, blank=True, on_delete=models.SET_NULL,
         verbose_name=ugettext_lazy('Team')
@@ -47,11 +47,14 @@ class Athlete(models.Model):
     )
     squad_position = models.IntegerField(default=-1, null=True, blank=True)
 
-    athletes_import = models.ForeignKey('AthletesImport', null=True, blank=True)
+    athletes_import = models.ForeignKey('AthletesImport', on_delete=models.CASCADE, null=True, blank=True)
 
     slug = models.SlugField(max_length=128, blank=True)
 
     objects = AthleteManager()
+
+    class Meta:
+        app_label = "athletes"
 
     def __str__(self):
         # Dev Output
@@ -98,6 +101,9 @@ class AthletesImport(models.Model):
     # name = models.CharField(max_length=50, null=False)
 
     club = models.OneToOneField('clubs.Club', null=True, blank=True, on_delete=models.SET_NULL, verbose_name=ugettext_lazy('Club'))
+
+    class Meta:
+        app_label = "athletes"
 
     def __str__(self):
         return '{0} #{1}'.format(ugettext_lazy('Athletes Import'), self.id)

--- a/Turnauswertung-py3/athletes/urls.py
+++ b/Turnauswertung-py3/athletes/urls.py
@@ -1,22 +1,22 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from athletes import views
 
 urlpatterns = [
-    url(r'^$', views.index_athletes, name='athletes.index'),
-    url(r'^new$', views.AthleteCreateView.as_view(), name='athletes.new'),
-    url(r'^results$', views.results, name='athletes.results'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)$',
+    path('', views.index_athletes, name='athletes.index'),
+    path('new', views.AthleteCreateView.as_view(), name='athletes.new'),
+    path('results', views.results, name='athletes.results'),
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)$',
         views.detail_athlete, name='athletes.detail'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/edit$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/edit$',
         views.AthleteUpdateView.as_view(), name='athletes.edit'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/delete$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/delete$',
         views.AthleteDeleteView.as_view(), name='athletes.delete'),
 
-    url(r'^imports/?$', views.index, name='athletes_imports.index'),
-    url(r'^imports/new$', views.new, name='athletes_imports.new'),
-    url(r'^imports/(?P<id>\d+)$',
+    re_path(r'^imports/?$', views.index, name='athletes_imports.index'),
+    path('imports/new', views.new, name='athletes_imports.new'),
+    path('imports/<int:id>',
         views.detail, name='athletes_imports.detail'),
-    url(r'^imports/(?P<pk>\d+)/delete$',
+    path('imports/<int:pk>/delete',
         views.DeleteView.as_view(), name='athletes_imports.delete'),
 ]

--- a/Turnauswertung-py3/athletes/views.py
+++ b/Turnauswertung-py3/athletes/views.py
@@ -1,12 +1,11 @@
-import json
 import datetime
+import json
 import re
 
-from django.http import HttpResponse
 from django.contrib import messages
-from django.core.urlresolvers import reverse, reverse_lazy
-from django.http import HttpResponseNotAllowed
+from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
+from django.urls import reverse, reverse_lazy
 from django.views import generic
 
 from athletes.models import Athlete, AthletesImport

--- a/Turnauswertung-py3/clubs/models.py
+++ b/Turnauswertung-py3/clubs/models.py
@@ -1,16 +1,16 @@
 from django.db import models
 from django.urls import reverse
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 
 class Club(models.Model):
 
-    name = models.CharField(ugettext_lazy('Name'), max_length=50)
+    name = models.CharField(gettext_lazy('Name'), max_length=50)
 
     address = models.ForeignKey(
         'common.Address', null=True, blank=True, on_delete=models.CASCADE,
-        verbose_name=ugettext_lazy('Address')
+        verbose_name=gettext_lazy('Address')
     )
 
     slug = models.SlugField(max_length=128, blank=True)

--- a/Turnauswertung-py3/clubs/models.py
+++ b/Turnauswertung-py3/clubs/models.py
@@ -1,19 +1,22 @@
-from django.core.urlresolvers import reverse
 from django.db import models
+from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy
 
 
 class Club(models.Model):
-  
+
     name = models.CharField(ugettext_lazy('Name'), max_length=50)
 
     address = models.ForeignKey(
-        'common.Address', null=True, blank=True,
+        'common.Address', null=True, blank=True, on_delete=models.CASCADE,
         verbose_name=ugettext_lazy('Address')
     )
 
     slug = models.SlugField(max_length=128, blank=True)
+
+    class Meta:
+        app_label = "clubs"
 
     def __str__(self):
         return self.name

--- a/Turnauswertung-py3/clubs/urls.py
+++ b/Turnauswertung-py3/clubs/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from clubs import views
 
 urlpatterns = [
-    url(r'^$', views.index, name='clubs.index'),
-    url(r'^new$', views.ClubCreateView.as_view(), name='clubs.new'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)$',
+    path('', views.index, name='clubs.index'),
+    path('new', views.ClubCreateView.as_view(), name='clubs.new'),
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)$',
         views.detail, name='clubs.detail'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/edit$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/edit$',
         views.ClubUpdateView.as_view(), name='clubs.edit'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/delete$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/delete$',
         views.ClubDeleteView.as_view(), name='clubs.delete'),
 ]

--- a/Turnauswertung-py3/clubs/views.py
+++ b/Turnauswertung-py3/clubs/views.py
@@ -1,13 +1,13 @@
 from django.contrib.messages.views import SuccessMessageMixin
-from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import render
+from django.urls import reverse_lazy
 from django.views import generic
 
 from clubs.models import Club
 
 
 def index(request):
-    context = { 
+    context = {
         'clubs': Club.objects.all() \
             .prefetch_related('athlete_set')
     }
@@ -22,8 +22,8 @@ def detail(request, id, slug):
     athletes = club.athlete_set.all() \
         .select_related('club').select_related('stream').select_related('team__stream').select_related('squad')
 
-    context = { 
-        'club': club, 
+    context = {
+        'club': club,
         'athletes': athletes,
     }
     return render(request, 'gymnastics/clubs/detail.html', context)

--- a/Turnauswertung-py3/common/models.py
+++ b/Turnauswertung-py3/common/models.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.db import models
+from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy
 
@@ -17,13 +17,14 @@ class Performance(models.Model):
     )
 
     athlete = models.ForeignKey(
-        "athletes.Athlete", verbose_name=ugettext_lazy("Athlete")
+        "athletes.Athlete", on_delete=models.CASCADE, verbose_name=ugettext_lazy("Athlete")
     )
     discipline = models.ForeignKey(
-        "Discipline", verbose_name=ugettext_lazy("Discipline")
+        "Discipline", on_delete=models.CASCADE, verbose_name=ugettext_lazy("Discipline")
     )
 
     class Meta:
+        app_label = "common"
         unique_together = (("athlete", "discipline"),)
 
     def __str__(self):
@@ -35,6 +36,9 @@ class Discipline(models.Model):
     name = models.CharField(ugettext_lazy("Name"), max_length=50, null=False)
 
     slug = models.SlugField(max_length=128, blank=True)
+
+    class Meta:
+        app_label = "common"
 
     def __str__(self):
         return self.name
@@ -65,6 +69,9 @@ class Address(models.Model):
     province = models.CharField(ugettext_lazy("Province"), max_length=128)
     zip_code = models.CharField(ugettext_lazy("Zip code"), max_length=10)
 
+    class Meta:
+        app_label = "common"
+
     @property
     def address_formatted(self):
         return "{}\n{} {}\n{}".format(
@@ -75,10 +82,11 @@ class Address(models.Model):
 class StreamDisciplineJoin(models.Model):
     position = models.IntegerField(null=True)
 
-    stream = models.ForeignKey("streams.Stream")
-    discipline = models.ForeignKey("Discipline")
+    stream = models.ForeignKey("streams.Stream", on_delete=models.CASCADE)
+    discipline = models.ForeignKey("Discipline", on_delete=models.CASCADE)
 
     class Meta:
+        app_label = "common"
         ordering = ["position"]
 
     def __str__(self):

--- a/Turnauswertung-py3/common/models.py
+++ b/Turnauswertung-py3/common/models.py
@@ -1,15 +1,15 @@
 from django.db import models
 from django.urls import reverse
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 
 class Performance(models.Model):
     value = models.DecimalField(
-        ugettext_lazy("Value"), null=False, max_digits=5, decimal_places=3, default=0.0
+        gettext_lazy("Value"), null=False, max_digits=5, decimal_places=3, default=0.0
     )
     value_final = models.DecimalField(
-        ugettext_lazy("Final Value"),
+        gettext_lazy("Final Value"),
         null=True,
         blank=True,
         max_digits=5,
@@ -17,10 +17,10 @@ class Performance(models.Model):
     )
 
     athlete = models.ForeignKey(
-        "athletes.Athlete", on_delete=models.CASCADE, verbose_name=ugettext_lazy("Athlete")
+        "athletes.Athlete", on_delete=models.CASCADE, verbose_name=gettext_lazy("Athlete")
     )
     discipline = models.ForeignKey(
-        "Discipline", on_delete=models.CASCADE, verbose_name=ugettext_lazy("Discipline")
+        "Discipline", on_delete=models.CASCADE, verbose_name=gettext_lazy("Discipline")
     )
 
     class Meta:
@@ -33,7 +33,7 @@ class Performance(models.Model):
 
 
 class Discipline(models.Model):
-    name = models.CharField(ugettext_lazy("Name"), max_length=50, null=False)
+    name = models.CharField(gettext_lazy("Name"), max_length=50, null=False)
 
     slug = models.SlugField(max_length=128, blank=True)
 
@@ -59,15 +59,15 @@ class Discipline(models.Model):
 
 
 class Address(models.Model):
-    contact_name = models.CharField(ugettext_lazy("Contact name"), max_length=64)
+    contact_name = models.CharField(gettext_lazy("Contact name"), max_length=64)
     phone = models.CharField(
-        ugettext_lazy("Contact phone"), max_length=15, null=True, blank=True
+        gettext_lazy("Contact phone"), max_length=15, null=True, blank=True
     )
-    email = models.EmailField(ugettext_lazy("Contact email"), null=True, blank=True)
-    street = models.CharField(ugettext_lazy("Street"), max_length=128)
-    city = models.CharField(ugettext_lazy("City"), max_length=128)
-    province = models.CharField(ugettext_lazy("Province"), max_length=128)
-    zip_code = models.CharField(ugettext_lazy("Zip code"), max_length=10)
+    email = models.EmailField(gettext_lazy("Contact email"), null=True, blank=True)
+    street = models.CharField(gettext_lazy("Street"), max_length=128)
+    city = models.CharField(gettext_lazy("City"), max_length=128)
+    province = models.CharField(gettext_lazy("Province"), max_length=128)
+    zip_code = models.CharField(gettext_lazy("Zip code"), max_length=10)
 
     class Meta:
         app_label = "common"

--- a/Turnauswertung-py3/common/urls.py
+++ b/Turnauswertung-py3/common/urls.py
@@ -1,47 +1,48 @@
+from django.urls import path, re_path
+
 from common import views
-from django.conf.urls import url
 
 urlpatterns = [
-    url(r"^$", views.index, name="home"),
-    url(r"^disciplines/?$", views.disciplines_index, name="disciplines.index"),
-    url(
-        r"^disciplines/new$",
+    path("", views.index, name="home"),
+    re_path(r"^disciplines/?$", views.disciplines_index, name="disciplines.index"),
+    path(
+        "disciplines/new",
         views.DisciplineCreateView.as_view(),
         name="disciplines.new",
     ),
-    url(
+    re_path(
         r"^disciplines/(?P<slug>[-\w\d]*)-(?P<id>\d+)$",
         views.discipline_detail,
         name="disciplines.detail",
     ),
-    url(
+    re_path(
         r"^disciplines/(?P<slug>[-\w\d]*)-(?P<pk>\d+)/edit$",
         views.DisciplineUpdateView.as_view(),
         name="disciplines.edit",
     ),
-    url(
+    re_path(
         r"^disciplines/(?P<slug>[-\w\d]*)-(?P<pk>\d+)/delete$",
         views.DisciplineDeleteView.as_view(),
         name="disciplines.delete",
     ),
-    url(r"^performances/?$", views.performances_index, name="performances.index"),
-    url(
-        r"^performances/new$",
+    re_path(r"^performances/?$", views.performances_index, name="performances.index"),
+    path(
+        "performances/new",
         views.PerformanceCreateView.as_view(),
         name="performances.new",
     ),
-    url(
-        r"^performances/(?P<pk>\d+)$",
+    path(
+        "performances/<int:pk>",
         views.PerformanceDetailView.as_view(),
         name="performances.detail",
     ),
-    url(
-        r"^performances/(?P<pk>\d+)/edit$",
+    path(
+        "performances/<int:pk>/edit",
         views.PerformanceUpdateView.as_view(),
         name="performances.edit",
     ),
-    url(
-        r"^performances/(?P<pk>\d+)/delete$",
+    path(
+        "performances/<int:pk>/delete",
         views.PerformanceDeleteView.as_view(),
         name="performances.delete",
     ),

--- a/Turnauswertung-py3/common/views.py
+++ b/Turnauswertung-py3/common/views.py
@@ -1,7 +1,8 @@
-from common.models import Discipline, Performance
-from django.core.urlresolvers import reverse, reverse_lazy
 from django.shortcuts import redirect, render
+from django.urls import reverse, reverse_lazy
 from django.views import generic
+
+from common.models import Discipline, Performance
 
 
 # renders index / home page

--- a/Turnauswertung-py3/requirements.txt
+++ b/Turnauswertung-py3/requirements.txt
@@ -1,7 +1,6 @@
 pre-commit
-Django==1.11.29
+Django==2.2
+# django-extensions==3.1.4
 django-bootstrap3==11.1.0
-django-debug-toolbar==1.6
 django-widget-tweaks==1.3
 # mysqlclient==1.3.9
-sqlparse==0.2.2

--- a/Turnauswertung-py3/requirements.txt
+++ b/Turnauswertung-py3/requirements.txt
@@ -1,6 +1,6 @@
 pre-commit
-Django==2.2
+Django==4.2
 # django-extensions==3.1.4
-django-bootstrap3==11.1.0
+django-bootstrap3==23.1
 django-widget-tweaks==1.3
 # mysqlclient==1.3.9

--- a/Turnauswertung-py3/squads/models.py
+++ b/Turnauswertung-py3/squads/models.py
@@ -3,12 +3,12 @@ import itertools
 from django.db import models
 from django.urls import reverse
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 
 class Squad(models.Model):
 
-    name = models.CharField(ugettext_lazy('Squad'), max_length=50, null=False)
+    name = models.CharField(gettext_lazy('Squad'), max_length=50, null=False)
 
     slug = models.SlugField(max_length=128, blank=True)
 

--- a/Turnauswertung-py3/squads/models.py
+++ b/Turnauswertung-py3/squads/models.py
@@ -1,16 +1,19 @@
 import itertools
 
-from django.core.urlresolvers import reverse
 from django.db import models
+from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy
 
 
 class Squad(models.Model):
-  
+
     name = models.CharField(ugettext_lazy('Squad'), max_length=50, null=False)
 
     slug = models.SlugField(max_length=128, blank=True)
+
+    class Meta:
+        app_label = "squads"
 
     def __str__(self):
         return self.name

--- a/Turnauswertung-py3/squads/urls.py
+++ b/Turnauswertung-py3/squads/urls.py
@@ -1,24 +1,24 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from squads import views
 
 urlpatterns = [
-    url(r'^$', views.index, name='squads.index'),
-    url(r'^judge\.pdf$', views.create_judge_pdf, name='squads.create_judge_pdf'),
-    url(r'^overview\.pdf$',
+    path('', views.index, name='squads.index'),
+    re_path(r'^judge\.pdf$', views.create_judge_pdf, name='squads.create_judge_pdf'),
+    re_path(r'^overview\.pdf$',
         views.create_overview_pdf, name='squads.create_overview_pdf'),
-    url(r'^handle_entered_performances$',
+    path('handle_entered_performances',
         views.handle_entered_performances,
         name='squads.handle_entered_performances'),
-    url(r'^new$', views.SquadCreateView.as_view(), name='squads.new'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)$',
+    path('new', views.SquadCreateView.as_view(), name='squads.new'),
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)$',
         views.detail, name='squads.detail'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/edit$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/edit$',
         views.SquadUpdateView.as_view(), name='squads.edit'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)/assign_athletes$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)/assign_athletes$',
         views.assign_athletes, name='squads.assign_athletes'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)/enter_performances$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)/enter_performances$',
         views.enter_performances, name='squads.enter_performances'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/delete$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/delete$',
         views.SquadDeleteView.as_view(), name='squads.delete'),
 ]

--- a/Turnauswertung-py3/squads/views.py
+++ b/Turnauswertung-py3/squads/views.py
@@ -4,7 +4,7 @@ from django.db.models import Sum
 from django.http import HttpResponseNotAllowed
 from django.shortcuts import redirect, render
 from django.urls import reverse, reverse_lazy
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 from django.views import generic
 
 from athletes.models import Athlete
@@ -168,7 +168,7 @@ def create_judge_pdf(request):
         'squad_difficulty_indices': squad_difficulty_indices,
     }
     template_location = 'gymnastics/documents/squads_judges.tex'
-    file_name = '{0}_{1}_{2}.pdf'.format(ugettext_lazy('Squads'), ugettext_lazy('Judge'), ugettext_lazy('Lists'))
+    file_name = '{0}_{1}_{2}.pdf'.format(gettext_lazy('Squads'), gettext_lazy('Judge'), gettext_lazy('Lists'))
 
     return pdf.create(template_location, context, file_name)
 
@@ -189,7 +189,7 @@ def create_overview_pdf(request):
         'squad_athletes_dict': squad_athletes_dict,
     }
     template_location = 'gymnastics/documents/squads_athletes.tex'
-    file_name = f"{ugettext_lazy('Squads')}_{ugettext_lazy('Overview')}.pdf"
+    file_name = f"{gettext_lazy('Squads')}_{gettext_lazy('Overview')}.pdf"
 
     return pdf.create(template_location, context, file_name)
 

--- a/Turnauswertung-py3/squads/views.py
+++ b/Turnauswertung-py3/squads/views.py
@@ -1,16 +1,16 @@
 import re
 
-from django.core.urlresolvers import reverse, reverse_lazy
 from django.db.models import Sum
 from django.http import HttpResponseNotAllowed
 from django.shortcuts import redirect, render
+from django.urls import reverse, reverse_lazy
 from django.utils.translation import ugettext_lazy
 from django.views import generic
 
-from utils import pdf
 from athletes.models import Athlete
-from squads.models import Squad
 from common.models import Performance
+from squads.models import Squad
+from utils import pdf
 from utils.dict_operations import completed_performances
 
 

--- a/Turnauswertung-py3/streams/models.py
+++ b/Turnauswertung-py3/streams/models.py
@@ -1,19 +1,19 @@
 import operator
 
-from django.core.urlresolvers import reverse
 from django.db import models
+from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy
 
 
 class Stream(models.Model):
-  
+
     difficulty = models.CharField(
         ugettext_lazy('Difficulty'), max_length=10, null=False)
     sex = models.CharField(ugettext_lazy('Sex'), max_length=1, null=False, choices=(('m', ugettext_lazy('male')), ('f', ugettext_lazy('female'))), default='f')
     minimum_year_of_birth = models.IntegerField(
         ugettext_lazy('Minimum Year of Birth'), default=2000, null=False)
-    
+
     all_around_individual = models.BooleanField(
         ugettext_lazy('All around individual'), default=True)
     all_around_individual_counting_events = models.IntegerField(
@@ -37,6 +37,9 @@ class Stream(models.Model):
         'common.Discipline', through='common.StreamDisciplineJoin')
 
     slug = models.SlugField(max_length=127, blank=True)
+
+    class Meta:
+        app_label = "streams"
 
     def __str__(self):
         return "{0} {1}".format(self.difficulty, self.get_sex_display())

--- a/Turnauswertung-py3/streams/models.py
+++ b/Turnauswertung-py3/streams/models.py
@@ -3,31 +3,31 @@ import operator
 from django.db import models
 from django.urls import reverse
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 
 class Stream(models.Model):
 
     difficulty = models.CharField(
-        ugettext_lazy('Difficulty'), max_length=10, null=False)
-    sex = models.CharField(ugettext_lazy('Sex'), max_length=1, null=False, choices=(('m', ugettext_lazy('male')), ('f', ugettext_lazy('female'))), default='f')
+        gettext_lazy('Difficulty'), max_length=10, null=False)
+    sex = models.CharField(gettext_lazy('Sex'), max_length=1, null=False, choices=(('m', gettext_lazy('male')), ('f', gettext_lazy('female'))), default='f')
     minimum_year_of_birth = models.IntegerField(
-        ugettext_lazy('Minimum Year of Birth'), default=2000, null=False)
+        gettext_lazy('Minimum Year of Birth'), default=2000, null=False)
 
     all_around_individual = models.BooleanField(
-        ugettext_lazy('All around individual'), default=True)
+        gettext_lazy('All around individual'), default=True)
     all_around_individual_counting_events = models.IntegerField(
         null=True, blank=True, default=4)
 
     all_around_team = models.BooleanField(
-        ugettext_lazy('All around team'), default=True)
+        gettext_lazy('All around team'), default=True)
     all_around_team_size = models.IntegerField(
         null=True, blank=True, default=4)
     all_around_team_counting_athletes = models.IntegerField(
         null=True, blank=True, default=4)
 
     discipline_finals = models.BooleanField(
-        ugettext_lazy('Discipline finals'), default=False)
+        gettext_lazy('Discipline finals'), default=False)
     discipline_finals_max_participants = models.IntegerField(
         null=True, blank=True)
     discipline_finals_both_values_count = models.BooleanField(

--- a/Turnauswertung-py3/streams/urls.py
+++ b/Turnauswertung-py3/streams/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from streams import views
 
 urlpatterns = [
-    url(r'^$', views.index, name='streams.index'),
-    url(r'^new$', views.new, name='streams.new'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)$',
+    path('', views.index, name='streams.index'),
+    path('new', views.new, name='streams.new'),
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)$',
         views.detail, name='streams.detail'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)/edit$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)/edit$',
         views.edit, name='streams.edit'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/delete$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/delete$',
         views.StreamDeleteView.as_view(), name='streams.delete'),
 ]

--- a/Turnauswertung-py3/streams/views.py
+++ b/Turnauswertung-py3/streams/views.py
@@ -1,12 +1,12 @@
 from django.contrib import messages
-from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponseNotAllowed
 from django.shortcuts import redirect, render
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy
 from django.views import generic
 
-from streams.models import Stream
 from common.models import Discipline, StreamDisciplineJoin
+from streams.models import Stream
 from utils.dict_operations import completed_performances
 
 
@@ -38,8 +38,8 @@ def detail(request, id, slug):
     teams_disciplines_result_dict = stream.get_teams_disciplines_result_dict()
     teams_disciplines_rank_dict = stream.get_teams_disciplines_rank_dict(teams_disciplines_result_dict)
 
-    context = { 
-        'stream': stream, 
+    context = {
+        'stream': stream,
         'disciplines': disciplines,
         'athletes': athletes,
         'athletes_count': len(athletes),
@@ -61,7 +61,7 @@ def new(request):
         return render(request, 'gymnastics/streams/new.html', context)
 
     elif request.method == 'POST':
-        stream = _build_stream_from_post(post_dict=request.POST);
+        stream = _build_stream_from_post(post_dict=request.POST)
         return redirect(stream.get_absolute_url())
 
     return HttpResponseNotAllowed(['GET', 'POST'])
@@ -74,18 +74,20 @@ def _build_stream_from_post(stream=None, post_dict={}, method='create'):
     try:
         selected_disciplines = [disciplines.get(id=discipline_id) for discipline_id in post_dict['chosen_list_order'].split()]
     except:
+        # TODO fix missing request param
         return _abort_stream_creation(request, ugettext_lazy('Error: At least one discipline was not found.'))
 
     # check if difficulty was given (necessary)
     try:
         difficulty=post_dict['difficulty']
     except:
+        # TODO fix missing request param
         return _abort_stream_creation(request, ugettext_lazy('Error: There is no difficulty given.'))
 
     if not stream:
         stream = Stream()
 
-    # set values from 
+    # set values from
     stream.difficulty = difficulty
     stream.sex=post_dict.get('sex', 'f')
     stream.minimum_year_of_birth=int(post_dict.get('minimum_year_of_birth', 2000))
@@ -119,6 +121,7 @@ def _build_stream_from_post(stream=None, post_dict={}, method='create'):
             stream_discipline_join.position = position
             stream_discipline_join.save()
     else:
+        # TODO fix missing request param
         return _abort_stream_creation(request, ugettext_lazy('Error: Unknown method.'))
 
     return stream
@@ -137,7 +140,7 @@ def edit(request, id, slug):
         stream = Stream.objects.get(id=id)
         disciplines = stream.discipline_set.all()
 
-        context = { 
+        context = {
             'stream': stream,
             'stream_disciplines': stream.get_ordered_disciplines(),
             'disciplines': [discipline for discipline in Discipline.objects.all() if discipline not in disciplines],

--- a/Turnauswertung-py3/streams/views.py
+++ b/Turnauswertung-py3/streams/views.py
@@ -2,7 +2,7 @@ from django.contrib import messages
 from django.http import HttpResponseNotAllowed
 from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 from django.views import generic
 
 from common.models import Discipline, StreamDisciplineJoin
@@ -75,14 +75,14 @@ def _build_stream_from_post(stream=None, post_dict={}, method='create'):
         selected_disciplines = [disciplines.get(id=discipline_id) for discipline_id in post_dict['chosen_list_order'].split()]
     except:
         # TODO fix missing request param
-        return _abort_stream_creation(request, ugettext_lazy('Error: At least one discipline was not found.'))
+        return _abort_stream_creation(request, gettext_lazy('Error: At least one discipline was not found.'))
 
     # check if difficulty was given (necessary)
     try:
         difficulty=post_dict['difficulty']
     except:
         # TODO fix missing request param
-        return _abort_stream_creation(request, ugettext_lazy('Error: There is no difficulty given.'))
+        return _abort_stream_creation(request, gettext_lazy('Error: There is no difficulty given.'))
 
     if not stream:
         stream = Stream()
@@ -122,7 +122,7 @@ def _build_stream_from_post(stream=None, post_dict={}, method='create'):
             stream_discipline_join.save()
     else:
         # TODO fix missing request param
-        return _abort_stream_creation(request, ugettext_lazy('Error: Unknown method.'))
+        return _abort_stream_creation(request, gettext_lazy('Error: Unknown method.'))
 
     return stream
 

--- a/Turnauswertung-py3/teams/models.py
+++ b/Turnauswertung-py3/teams/models.py
@@ -1,17 +1,17 @@
 from django.db import models
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 
 class Team(models.Model):
 
-    name = models.CharField(ugettext_lazy('Name'), max_length=128, null=False)
+    name = models.CharField(gettext_lazy('Name'), max_length=128, null=False)
 
     club = models.ForeignKey(
-        'clubs.Club', null=True, blank=True, on_delete=models.CASCADE, verbose_name=ugettext_lazy('Club')
+        'clubs.Club', null=True, blank=True, on_delete=models.CASCADE, verbose_name=gettext_lazy('Club')
     )
     stream = models.ForeignKey(
-        'streams.Stream', on_delete=models.CASCADE, verbose_name=ugettext_lazy('Stream'))
+        'streams.Stream', on_delete=models.CASCADE, verbose_name=gettext_lazy('Stream'))
 
     class Meta:
         app_label = "teams"

--- a/Turnauswertung-py3/teams/models.py
+++ b/Turnauswertung-py3/teams/models.py
@@ -1,17 +1,20 @@
-from django.core.urlresolvers import reverse
 from django.db import models
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy
 
 
 class Team(models.Model):
-  
+
     name = models.CharField(ugettext_lazy('Name'), max_length=128, null=False)
 
     club = models.ForeignKey(
-        'clubs.Club', null=True, blank=True, verbose_name=ugettext_lazy('Club')
+        'clubs.Club', null=True, blank=True, on_delete=models.CASCADE, verbose_name=ugettext_lazy('Club')
     )
     stream = models.ForeignKey(
-        'streams.Stream', verbose_name=ugettext_lazy('Stream'))
+        'streams.Stream', on_delete=models.CASCADE, verbose_name=ugettext_lazy('Stream'))
+
+    class Meta:
+        app_label = "teams"
 
     def __str__(self):
         return '{0} ({1})'.format(self.name, self.stream)

--- a/Turnauswertung-py3/teams/urls.py
+++ b/Turnauswertung-py3/teams/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from teams import views
 
 urlpatterns = [
-    url(r'^teams/?$', views.index, name='teams.index'),
-    url(r'^teams/new$', views.TeamCreateView.as_view(), name='teams.new'),
-    url(r'^teams/(?P<id>\d+)$', views.detail, name='teams.detail'),
-    url(r'^teams/(?P<pk>\d+)/edit$',
+    re_path(r'^teams/?$', views.index, name='teams.index'),
+    path('teams/new', views.TeamCreateView.as_view(), name='teams.new'),
+    path('teams/<int:id>', views.detail, name='teams.detail'),
+    path('teams/<int:pk>/edit',
         views.TeamUpdateView.as_view(), name='teams.edit'),
-    url(r'^teams/(?P<pk>\d+)/delete$',
+    path('teams/<int:pk>/delete',
         views.TeamDeleteView.as_view(), name='teams.delete'),
 ]

--- a/Turnauswertung-py3/teams/views.py
+++ b/Turnauswertung-py3/teams/views.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse, reverse_lazy
 from django.shortcuts import render
+from django.urls import reverse, reverse_lazy
 from django.views import generic
 
 from teams.models import Team
@@ -13,7 +13,7 @@ def index(request):
 
 def detail(request, id):
     team = Team.objects.get(id=id)
-    context = { 
+    context = {
         'team': team,
         'club': team.club,
         'stream': team.stream }

--- a/Turnauswertung-py3/templates/gymnastics/base.html
+++ b/Turnauswertung-py3/templates/gymnastics/base.html
@@ -16,7 +16,7 @@
   </head>
   <body>
     
-    <div id="doc" class="container">
+    <div id="doc">
 
       <!-- top navbar -->
       <div class="navbar navbar-fixed-top navbar-inverse static-navbar" role="navigation">

--- a/Turnauswertung-py3/templates/gymnastics/base.html
+++ b/Turnauswertung-py3/templates/gymnastics/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 {% load custom_template_tags %}
 
@@ -16,7 +16,7 @@
   </head>
   <body>
     
-    <div id="doc" class"container">
+    <div id="doc" class="container">
 
       <!-- top navbar -->
       <div class="navbar navbar-fixed-top navbar-inverse static-navbar" role="navigation">

--- a/Turnauswertung-py3/templates/gymnastics/index.html
+++ b/Turnauswertung-py3/templates/gymnastics/index.html
@@ -1,7 +1,7 @@
 {% extends "gymnastics/base.html" %}
 
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block headline %}{% endblock headline %}
 {% block nav_main %}{% trans 'Home' %}{% endblock nav_main %}

--- a/Turnauswertung-py3/templates/gymnastics/squads/enter_performances.html
+++ b/Turnauswertung-py3/templates/gymnastics/squads/enter_performances.html
@@ -63,7 +63,7 @@
 {% endblock content %}
 
 {% block javascript %}
-  {% load staticfiles %}
+  {% load static %}
   
   <script src="{% static 'gymnastics/js/turnen.key-changes.js' %}"></script>
 {% endblock javascript %}

--- a/Turnauswertung-py3/tournaments/models.py
+++ b/Turnauswertung-py3/tournaments/models.py
@@ -1,10 +1,7 @@
 import datetime
 
-# from django import forms
-# from django.contrib.admin.widgets import AdminDateWidget
-
-from django.core.urlresolvers import reverse
 from django.db import models
+from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy
 
@@ -30,15 +27,18 @@ class Tournament(models.Model):
         ugettext_lazy('Technology'), max_length=128, null=True, blank=True)
 
     address = models.ForeignKey(
-        'common.Address', null=True, blank=True,
+        'common.Address', null=True, blank=True, on_delete=models.CASCADE,
         verbose_name=ugettext_lazy('Address')
     )
     hosting_club = models.ForeignKey(
-        'clubs.Club', null=True, blank=True,
+        'clubs.Club', null=True, blank=True, on_delete=models.CASCADE,
         verbose_name=ugettext_lazy('Hosting club')
     )
 
     slug = models.SlugField(max_length=128, blank=True)
+
+    class Meta:
+        app_label = "tournaments"
 
     def __str__(self):
         return '{0}'.format(self.name)
@@ -67,22 +67,24 @@ class Tournament(models.Model):
         return reverse('tournaments.create_team_certificate_data_txt', kwargs={ 'id': self.id, 'slug': self.slug })
 
     def get_evaluation_data(self):
-        streams = Stream.objects.all() \
-            .prefetch_related('discipline_set') \
-            .prefetch_related('athlete_set') \
-                .prefetch_related('athlete_set__club') \
-                .prefetch_related('athlete_set__stream') \
-                .prefetch_related('athlete_set__squad') \
-                .prefetch_related('athlete_set__team__stream') \
-                .prefetch_related('athlete_set__performance_set') \
-                .prefetch_related('athlete_set__performance_set__discipline') \
-            .prefetch_related('team_set') \
-                .prefetch_related('team_set__stream') \
-                .prefetch_related('team_set__club') \
-                .prefetch_related('team_set__stream') \
-                .prefetch_related('team_set__athlete_set') \
-                .prefetch_related('team_set__athlete_set__performance_set') \
+        streams = (
+            Stream.objects.all()
+            .prefetch_related('discipline_set')
+            .prefetch_related('athlete_set')
+            .prefetch_related('athlete_set__club')
+            .prefetch_related('athlete_set__stream')
+            .prefetch_related('athlete_set__squad')
+            .prefetch_related('athlete_set__team__stream')
+            .prefetch_related('athlete_set__performance_set')
+            .prefetch_related('athlete_set__performance_set__discipline')
+            .prefetch_related('team_set')
+            .prefetch_related('team_set__stream')
+            .prefetch_related('team_set__club')
+            .prefetch_related('team_set__stream')
+            .prefetch_related('team_set__athlete_set')
+            .prefetch_related('team_set__athlete_set__performance_set')
             .order_by('sex', '-minimum_year_of_birth', 'difficulty')
+        )
 
         athlete_disciplines_rank_dict = {}
         athlete_disciplines_result_dict = {}

--- a/Turnauswertung-py3/tournaments/models.py
+++ b/Turnauswertung-py3/tournaments/models.py
@@ -3,7 +3,7 @@ import datetime
 from django.db import models
 from django.urls import reverse
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 from streams.models import Stream
 
@@ -11,28 +11,28 @@ from streams.models import Stream
 class Tournament(models.Model):
 
     name = models.CharField(
-        ugettext_lazy('Name'), max_length=50, default='KJSS 2015')
-    name_full = models.CharField(ugettext_lazy('Full Name'), max_length=255)
-    date = models.DateField(ugettext_lazy('Date'), default=datetime.date.today)
+        gettext_lazy('Name'), max_length=50, default='KJSS 2015')
+    name_full = models.CharField(gettext_lazy('Full Name'), max_length=255)
+    date = models.DateField(gettext_lazy('Date'), default=datetime.date.today)
     region = models.CharField(
-        ugettext_lazy('Region'), max_length=128, null=True, blank=True)
+        gettext_lazy('Region'), max_length=128, null=True, blank=True)
 
     management = models.CharField(
-        ugettext_lazy('Management'), max_length=128, null=True, blank=True)
+        gettext_lazy('Management'), max_length=128, null=True, blank=True)
     organisation = models.CharField(
-        ugettext_lazy('Organisation'), max_length=128, null=True, blank=True)
+        gettext_lazy('Organisation'), max_length=128, null=True, blank=True)
     calculation = models.CharField(
-        ugettext_lazy('Calculation'), max_length=128, null=True, blank=True)
+        gettext_lazy('Calculation'), max_length=128, null=True, blank=True)
     technology = models.CharField(
-        ugettext_lazy('Technology'), max_length=128, null=True, blank=True)
+        gettext_lazy('Technology'), max_length=128, null=True, blank=True)
 
     address = models.ForeignKey(
         'common.Address', null=True, blank=True, on_delete=models.CASCADE,
-        verbose_name=ugettext_lazy('Address')
+        verbose_name=gettext_lazy('Address')
     )
     hosting_club = models.ForeignKey(
         'clubs.Club', null=True, blank=True, on_delete=models.CASCADE,
-        verbose_name=ugettext_lazy('Hosting club')
+        verbose_name=gettext_lazy('Hosting club')
     )
 
     slug = models.SlugField(max_length=128, blank=True)

--- a/Turnauswertung-py3/tournaments/urls.py
+++ b/Turnauswertung-py3/tournaments/urls.py
@@ -1,26 +1,26 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from tournaments import views
 
 urlpatterns = [
-    url(r'^$', views.index, name='tournaments.index'),
-    url(r'^main$', views.main, name='tournaments.main'),
-    url(r'^new$',
+    path('', views.index, name='tournaments.index'),
+    path('main', views.main, name='tournaments.main'),
+    path('new',
         views.TournamentCreateView.as_view(), name='tournaments.new'),
-    url(r'^certificates\.pdf$', views.create_certificates_pdf,
+    re_path(r'^certificates\.pdf$', views.create_certificates_pdf,
         name='tournaments.create_certificates_pdf'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)/evaluation\.pdf$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)/evaluation\.pdf$',
         views.create_evaluation_pdf, name='tournaments.create_evaluation_pdf'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)/solo_certificate_data\.txt$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)/solo_certificate_data\.txt$',
         views.create_solo_certificate_data_txt,
         name='tournaments.create_solo_certificate_data_txt'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)/team_certificate_data\.txt$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)/team_certificate_data\.txt$',
         views.create_team_certificate_data_txt,
         name='tournaments.create_team_certificate_data_txt'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<id>\d+)$',
         views.detail, name='tournaments.detail'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/edit$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/edit$',
         views.TournamentUpdateView.as_view(), name='tournaments.edit'),
-    url(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/delete$',
+    re_path(r'^(?P<slug>[-\w\d]*)-(?P<pk>\d+)/delete$',
         views.TournamentDeleteView.as_view(), name='tournaments.delete'),
 ]

--- a/Turnauswertung-py3/tournaments/views.py
+++ b/Turnauswertung-py3/tournaments/views.py
@@ -3,7 +3,7 @@ import json
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse, reverse_lazy
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 from django.views import generic
 
 from clubs.models import Club
@@ -43,7 +43,7 @@ def create_certificates_pdf(request):
         'squads': [],
     }
     template_location = 'gymnastics/documents/certificates.tex'
-    file_name = 'filename={0}.pdf'.format(ugettext_lazy('Certificates'))
+    file_name = 'filename={0}.pdf'.format(gettext_lazy('Certificates'))
 
     return pdf.create(template_location, context, file_name)
 
@@ -69,7 +69,7 @@ def create_solo_certificate_data_txt(request, id, slug):
     }
 
     template_location = 'gymnastics/documents/certificate_data_solo.txt'
-    file_name = '{}.txt'.format(ugettext_lazy('solo_certificate_data'))
+    file_name = '{}.txt'.format(gettext_lazy('solo_certificate_data'))
 
     return txt.create(template_location, context, file_name)
 
@@ -100,7 +100,7 @@ def create_team_certificate_data_txt(request, id, slug):
     }
 
     template_location = 'gymnastics/documents/certificate_data_team.txt'
-    file_name = '{}.txt'.format(ugettext_lazy('team_certificate_data'))
+    file_name = '{}.txt'.format(gettext_lazy('team_certificate_data'))
 
     return txt.create(template_location, context, file_name)
 
@@ -144,7 +144,7 @@ def create_evaluation_pdf(request, id, slug):
     context['total_athletes'] = sum([len(athlete_list) for athlete_list in stream_athletes_dict.values()])
 
     template_location = 'gymnastics/documents/evaluation.tex'
-    file_name = '{}.pdf'.format(ugettext_lazy('Evaluation'))
+    file_name = '{}.pdf'.format(gettext_lazy('Evaluation'))
 
     return pdf.create(template_location, context, file_name)
 

--- a/Turnauswertung-py3/tournaments/views.py
+++ b/Turnauswertung-py3/tournaments/views.py
@@ -1,14 +1,14 @@
 import json
 
-from django.core.urlresolvers import reverse, reverse_lazy
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
+from django.urls import reverse, reverse_lazy
 from django.utils.translation import ugettext_lazy
 from django.views import generic
 
-from utils import pdf, txt
 from clubs.models import Club
 from tournaments.models import Tournament
+from utils import pdf, txt
 
 
 def index(request):

--- a/Turnauswertung-py3/utils/templatetags/custom_template_tags.py
+++ b/Turnauswertung-py3/utils/templatetags/custom_template_tags.py
@@ -1,5 +1,5 @@
 from django import template
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 register = template.Library()
 
@@ -7,7 +7,7 @@ register = template.Library()
 @register.inclusion_tag('templatetags/nav_item.html')
 def render_nav_item(name, url_name='', url_id=None, active=False):
     return {
-        'name': ugettext_lazy(str(name)),
+        'name': gettext_lazy(str(name)),
         'url_name': url_name,
         'url_id': url_id,
         'active': active


### PR DESCRIPTION
Details
- Upgrade django to 4.2
- Removed explicit sqlparse dependency because it's implicit in django 2.2+
- Removed django admin because it wasn't used and broke
- Removed debug toolbar because it (hopefully) wasn't used and broke
- Upgrade bootstrap3 to 23.1
- Fixed moved django url imports
- Explicit on_delete definition for all foreign keys as required. Kept current default behavior of `on_delete=models.CASCADE`.
- Defined `app_label` for all models as required 
- Replaced `{% load staticfiles %}` template tag with `{% load static %}` as required
- Ran https://github.com/adamchainz/django-upgrade via precommit to fix v3 url definitions and translation imports
- Ran limited pre-commit to avoid too many distracting changes but a couple snuck in anyways

Known issues
- Possibly drag and drop issue in assign athletes when dropping athletes. Clicking to assign still functional. https://github.com/saechtner/turn-events/issues/21